### PR TITLE
Unicode error when using with rest-framework

### DIFF
--- a/multilingualfield/datastructures.py
+++ b/multilingualfield/datastructures.py
@@ -4,7 +4,7 @@ from __future__ import (
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_str, smart_unicode
 from django.utils.translation import get_language
 
 from lxml import objectify, etree
@@ -93,7 +93,7 @@ class MultiLingualText(object):
 
     def __unicode__(self):
         val = self.get_for_current_language()
-        return smart_str(val, errors='strict')
+        return smart_unicode(val, errors='strict')
 
     def as_xml(self):
         u"""Returns this instance as XML."""

--- a/multilingualfield/widgets.py
+++ b/multilingualfield/widgets.py
@@ -201,7 +201,7 @@ class MultiLingualTextFieldWidget(MultiLingualFieldBaseMixInWidget,
         to the current ordering of settings.LANGUAGES.
         """
         text_dict = {}
-        if value:
+        if value is not None:
             # Both MultiLingualCharField and MultiLingualTextField instances
             # provide `MultiLingualText` instances by default but handling
             # for raw XML has been included for convenience.
@@ -225,7 +225,8 @@ class MultiLingualTextFieldWidget(MultiLingualFieldBaseMixInWidget,
                     # value XML with the language code (i.e. 'en', 'de', 'fr')
                     # as the key
                     text_dict = dict(
-                        (unicode(l.code), unicode(l.language_text or u''))
+                        (unicode(l.get('code')),
+                         unicode(l.get('language_text') or u''))
                         for l in xml_as_python_object.language
                     )
         # Returning text from XML tree in order dictated by LANGUAGES

--- a/multilingualfield/widgets.py
+++ b/multilingualfield/widgets.py
@@ -224,11 +224,12 @@ class MultiLingualTextFieldWidget(MultiLingualFieldBaseMixInWidget,
                     # Creating a dictionary of all the languages passed in the
                     # value XML with the language code (i.e. 'en', 'de', 'fr')
                     # as the key
-                    text_dict = dict(
-                        (unicode(l.get('code')),
-                         unicode(l.get('language_text') or u''))
-                        for l in xml_as_python_object.language
-                    )
+                    if hasattr(xml_as_python_object, 'language'):
+                        text_dict = dict(
+                            (unicode(l.get('code')),
+                             unicode(l.get('language_text') or u''))
+                            for l in xml_as_python_object.language
+                        )
         # Returning text from XML tree in order dictated by LANGUAGES
         return [text_dict.get(code, u'') for code, verbose in LANGUAGES]
 


### PR DESCRIPTION
I believe that __unicode__ should return always unicode type. With python 2.7, Django 1.8 __unicode__ returned str, witch gave unicode error later on